### PR TITLE
Handle various orders of input data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Creates a stream tube plot of a vector field.
 * `params` is an object that has the following properties:
 
     + `startingPositions` *(Required)* An array of starting positions for the vector field, encoded as arrays.
-    + `getVelocity(point)` *(Required)* A getter function to get the velocity at a given point.
+    + `getVelocity(point)` *(Optional)* A getter function to get the velocity at a given point.
     + `getDivergence(point)` *(Optional)* A getter function to get the divergence at a given point. Used for the width of the streamtube. Defaults to the divergence of the getVelocity function.
     + `maxLength` *(Optional)* The maximum number of segments to add to a streamtube. Default is 1000.
     + `tubeSize` *(Optional)* The scaling factor for the streamtubes. The default is 1, which avoids two max divergence tubes from touching at adjacent starting positions.
-    + `absoluteTubeSize` *(Optional)* Absolute scaling factor for the streamtubes. A value of 1 scales divergence of 1 to 1 coordinate system unit. Overrides tubeSize. 
+    + `absoluteTubeSize` *(Optional)* Absolute scaling factor for the streamtubes. A value of 1 scales divergence of 1 to 1 coordinate system unit. Overrides tubeSize.
     + `colormap` *(Optional)* The colormap to use.
 
 **Returns** A streamtube plot object that can be passed to gl-mesh3d.

--- a/lib/shaders.js
+++ b/lib/shaders.js
@@ -10,7 +10,6 @@ exports.meshShader = {
   fragment: triFragSrc,
   attributes: [
     {name: 'position', type: 'vec4'},
-    {name: 'normal', type: 'vec3'},
     {name: 'color', type: 'vec4'},
     {name: 'uv', type: 'vec2'},
     {name: 'vector', type: 'vec4'}

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -6,19 +6,10 @@ precision highp float;
 #pragma glslify: outOfRange = require(glsl-out-of-range)
 
 uniform vec3 clipBounds[2];
-uniform float roughness
-            , fresnel
-            , kambient
-            , kdiffuse
-            , kspecular
-            , opacity;
+uniform float roughness, fresnel, kambient, kdiffuse, kspecular, opacity;
 uniform sampler2D texture;
 
-varying vec3 f_normal
-           , f_lightDirection
-           , f_eyeDirection
-           , f_data
-           , f_position;
+varying vec3 f_normal, f_lightDirection, f_eyeDirection, f_data, f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -5,21 +5,12 @@ precision highp float;
 attribute vec4 vector;
 attribute vec4 color, position;
 attribute vec2 uv;
-uniform float vectorScale;
-uniform float tubeScale;
 
-uniform mat4 model
-           , view
-           , projection
-           , inverseModel;
-uniform vec3 eyePosition
-           , lightPosition;
+uniform float vectorScale, tubeScale;
+uniform mat4 model, view, projection, inverseModel;
+uniform vec3 eyePosition, lightPosition;
 
-varying vec3 f_normal
-           , f_lightDirection
-           , f_eyeDirection
-           , f_data
-           , f_position;
+varying vec3 f_normal, f_lightDirection, f_eyeDirection, f_data, f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 
@@ -35,7 +26,7 @@ void main() {
   cameraCoordinate.xyz /= cameraCoordinate.w;
   f_lightDirection = lightPosition - cameraCoordinate.xyz;
   f_eyeDirection   = eyePosition - cameraCoordinate.xyz;
-  f_normal = normalize((vec4(normal,0.0) * inverseModel).xyz);
+  f_normal = normalize((vec4(normal, 0.0) * inverseModel).xyz);
 
   // vec4 m_position  = model * vec4(tubePosition, 1.0);
   vec4 t_position  = view * tubePosition;

--- a/lib/tubemesh.js
+++ b/lib/tubemesh.js
@@ -1,13 +1,9 @@
 'use strict'
 
-var DEFAULT_VERTEX_NORMALS_EPSILON = 1e-6; // may be too large if triangles are very small
-var DEFAULT_FACE_NORMALS_EPSILON = 1e-6;
-
 var createShader  = require('gl-shader')
 var createBuffer  = require('gl-buffer')
 var createVAO     = require('gl-vao')
 var createTexture = require('gl-texture2d')
-var normals       = require('normals')
 var multiply      = require('gl-mat4/multiply')
 var invert        = require('gl-mat4/invert')
 var ndarray       = require('ndarray')
@@ -34,7 +30,6 @@ function SimplicialMesh(gl
   , triangleIds
   , triangleColors
   , triangleUVs
-  , triangleNormals
   , triangleVAO
   , edgePositions
   , edgeIds
@@ -63,7 +58,6 @@ function SimplicialMesh(gl
   this.trianglePositions = trianglePositions
   this.triangleVectors   = triangleVectors
   this.triangleColors    = triangleColors
-  this.triangleNormals   = triangleNormals
   this.triangleUVs       = triangleUVs
   this.triangleIds       = triangleIds
   this.triangleVAO       = triangleVAO
@@ -294,18 +288,6 @@ proto.update = function(params) {
   this.cells     = cells
   this.positions = positions
   this.vectors   = vectors
-
-  //Compute normals
-  var vertexNormals = params.vertexNormals
-  var cellNormals   = params.cellNormals
-  var vertexNormalsEpsilon = params.vertexNormalsEpsilon === void(0) ? DEFAULT_VERTEX_NORMALS_EPSILON : params.vertexNormalsEpsilon
-  var faceNormalsEpsilon = params.faceNormalsEpsilon === void(0) ? DEFAULT_FACE_NORMALS_EPSILON : params.faceNormalsEpsilon
-  if(params.useFacetNormals && !cellNormals) {
-    cellNormals = normals.faceNormals(cells, positions, faceNormalsEpsilon)
-  }
-  if(!cellNormals && !vertexNormals) {
-    vertexNormals = normals.vertexNormals(cells, positions, vertexNormalsEpsilon)
-  }
 
   //Compute colors
   var vertexColors    = params.vertexColors
@@ -553,14 +535,6 @@ fill_loop:
           }
           tUVs.push(uv[0], uv[1])
 
-          var q
-          if(vertexNormals) {
-            q = vertexNormals[v]
-          } else {
-            q = cellNormals[i]
-          }
-          tNor.push(q[0], q[1], q[2])
-
           tIds.push(i)
         }
         triangleCount += 1
@@ -590,7 +564,6 @@ fill_loop:
   this.triangleVectors.update(tVec)
   this.triangleColors.update(tCol)
   this.triangleUVs.update(tUVs)
-  this.triangleNormals.update(tNor)
   this.triangleIds.update(new Uint32Array(tIds))
 }
 
@@ -761,7 +734,6 @@ proto.dispose = function() {
   this.triangleVectors.dispose()
   this.triangleColors.dispose()
   this.triangleUVs.dispose()
-  this.triangleNormals.dispose()
   this.triangleIds.dispose()
 
   this.edgeVAO.dispose()
@@ -786,7 +758,7 @@ function createMeshShader(gl) {
   shader.attributes.position.location = 0
   shader.attributes.color.location    = 2
   shader.attributes.uv.location       = 3
-  shader.attributes.vector.location   = 5
+  shader.attributes.vector.location   = 4
   return shader
 }
 
@@ -795,7 +767,7 @@ function createPickShader(gl) {
   var shader = createShader(gl, pickShader.vertex, pickShader.fragment, null, pickShader.attributes)
   shader.attributes.position.location = 0
   shader.attributes.id.location       = 1
-  shader.attributes.vector.location   = 5
+  shader.attributes.vector.location   = 4
   return shader
 }
 
@@ -819,7 +791,6 @@ function createSimplicialMesh(gl, params) {
   var triangleVectors   = createBuffer(gl)
   var triangleColors    = createBuffer(gl)
   var triangleUVs       = createBuffer(gl)
-  var triangleNormals   = createBuffer(gl)
   var triangleIds       = createBuffer(gl)
   var triangleVAO       = createVAO(gl, [
     { buffer: trianglePositions,
@@ -838,10 +809,6 @@ function createSimplicialMesh(gl, params) {
     { buffer: triangleUVs,
       type: gl.FLOAT,
       size: 2
-    },
-    { buffer: triangleNormals,
-      type: gl.FLOAT,
-      size: 3
     },
     { buffer: triangleVectors,
       type: gl.FLOAT,
@@ -918,7 +885,6 @@ function createSimplicialMesh(gl, params) {
     , triangleIds
     , triangleColors
     , triangleUVs
-    , triangleNormals
     , triangleVAO
     , edgePositions
     , edgeIds

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,15 +81,6 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
       "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
     },
-    "barycentric": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
-      "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
-      "dev": true,
-      "requires": {
-        "robust-linear-solve": "^1.0.0"
-      }
-    },
     "big-rat": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
@@ -694,29 +685,6 @@
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
       "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
     },
-    "gl-mesh3d": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.1.1.tgz",
-      "integrity": "sha512-UuDnuSE/xX8y9/B6EtDsBKllEmKDVmuiD9lsFoQdUq4FPSvwFOo9rKH3fsjK2pfxsTigguF6GhFjHqq+sJKQWg==",
-      "dev": true,
-      "requires": {
-        "barycentric": "^1.0.1",
-        "colormap": "^2.3.1",
-        "gl-buffer": "^2.0.8",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.8",
-        "gl-vao": "^1.1.3",
-        "glsl-out-of-range": "^1.0.4",
-        "glsl-specular-cook-torrance": "^2.0.1",
-        "glslify": "^7.0.0",
-        "ndarray": "^1.0.15",
-        "normals": "^1.0.1",
-        "polytope-closest-point": "^1.0.0",
-        "simplicial-complex-contour": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
-      }
-    },
     "gl-quat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
@@ -849,14 +817,12 @@
     "glsl-specular-beckmann": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
-      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE=",
-      "dev": true
+      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
     },
     "glsl-specular-cook-torrance": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
-      "dev": true,
       "requires": {
         "glsl-specular-beckmann": "^1.1.1"
       }
@@ -1297,17 +1263,6 @@
         "double-bits": "^1.1.0"
       }
     },
-    "normals": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
-      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
-    },
-    "numeric": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao=",
-      "dev": true
-    },
     "object-inspect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
@@ -1425,15 +1380,6 @@
         "slab-decomposition": "^1.0.1"
       }
     },
-    "polytope-closest-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
-      "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
-      "dev": true,
-      "requires": {
-        "numeric": "^1.2.6"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1544,24 +1490,6 @@
       "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg=",
       "dev": true
     },
-    "robust-compress": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
-      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs=",
-      "dev": true
-    },
-    "robust-determinant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
-      "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
-      "dev": true,
-      "requires": {
-        "robust-compress": "^1.0.0",
-        "robust-scale": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.0"
-      }
-    },
     "robust-dot-product": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
@@ -1582,15 +1510,6 @@
         "robust-subtract": "^1.0.0",
         "robust-sum": "^1.0.0",
         "two-product": "^1.0.0"
-      }
-    },
-    "robust-linear-solve": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
-      "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
-      "dev": true,
-      "requires": {
-        "robust-determinant": "^1.1.0"
       }
     },
     "robust-orientation": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "gl-vec4": "^1.0.1",
     "glsl-inverse": "^1.0.0",
     "glsl-out-of-range": "^1.0.4",
+    "glsl-specular-cook-torrance": "^2.0.1",
     "glslify": "^7.0.0",
     "ndarray": "^1.0.18",
-    "normals": "^1.1.0",
     "simplicial-complex-contour": "^1.0.2",
     "typedarray-pool": "^1.1.0"
   },
@@ -29,7 +29,6 @@
     "canvas-fit": "^1.5.0",
     "chttps": "^1.0.6",
     "gl-axes3d": "^1.5.2",
-    "gl-mesh3d": "^2.1.1",
     "gl-select-static": "^2.0.4",
     "gl-spikes3d": "^1.0.9"
   },

--- a/streamtube.js
+++ b/streamtube.js
@@ -207,10 +207,6 @@ var sampleMeshgrid = function(point, array, meshgrid, clampOverflow, gridFill) {
 	var y1 = y0 + 1;
 	var z1 = z0 + 1;
 
-	if (meshgrid[0][x0] === x) x1 = x0;
-	if (meshgrid[1][y0] === y) y1 = y0;
-	if (meshgrid[2][z0] === z) z1 = z0;
-
 	if (clampOverflow) {
 		x0 = clamp(x0, 0, w-1);
 		x1 = clamp(x1, 0, w-1);
@@ -221,7 +217,7 @@ var sampleMeshgrid = function(point, array, meshgrid, clampOverflow, gridFill) {
 	}
 
 	// Reject points outside the meshgrid, return a zero vector.
-	if (x0 < 0 || y0 < 0 || z0 < 0 || x1 >= w || y1 >= h || z1 >= d) {
+	if (x0 < 0 || y0 < 0 || z0 < 0 || x1 > w-1 || y1 > h-1 || z1 > d-1) {
 		return vec3.create();
 	}
 
@@ -236,13 +232,9 @@ var sampleMeshgrid = function(point, array, meshgrid, clampOverflow, gridFill) {
 	var yf = (y - mY0) / (mY1 - mY0);
 	var zf = (z - mZ0) / (mZ1 - mZ0);
 
-	// Likely we don't need these tests:
-	if (!isFinite(xf)) xf = 0;
-	if (!isFinite(yf)) yf = 0;
-	if (!isFinite(zf)) zf = 0;
-	xf = Math.max(0, Math.min(1, xf));
-	yf = Math.max(0, Math.min(1, yf));
-	zf = Math.max(0, Math.min(1, zf));
+	if (!isFinite(xf)) xf = 0.5;
+	if (!isFinite(yf)) yf = 0.5;
+	if (!isFinite(zf)) zf = 0.5;
 
 	var x0off;
 	var x1off;

--- a/streamtube.js
+++ b/streamtube.js
@@ -243,6 +243,24 @@ var sampleMeshgrid = function(point, array, meshgrid, clampOverflow, gridFill) {
 	var z0off;
 	var z1off;
 
+	if(gridFill.indexOf('-x') !== -1) {
+		x0 = w - 1 - x0;
+		x1 = w - 1 - x1;
+	}
+
+	if(gridFill.indexOf('-y') !== -1) {
+		y0 = h - 1 - y0;
+		y1 = h - 1 - y1;
+	}
+
+	if(gridFill.indexOf('-z') !== -1) {
+		z0 = d - 1 - z0;
+		z1 = d - 1 - z1;
+	}
+
+	gridFill = gridFill.replace(/-/g, '');
+	gridFill = gridFill.replace(/\+/g, '');
+
 	switch(gridFill) {
 		case 'xyz':
 			x0off = x0;
@@ -424,7 +442,7 @@ module.exports = function(vectorField, bounds) {
 	var absoluteTubeSize = vectorField.absoluteTubeSize;
 
 	if (!vectorField.gridFill) {
-		vectorField.gridFill = 'xyz';
+		vectorField.gridFill = '+x+y+z';
 	}
 
 	if (!vectorField.getDivergence) {

--- a/streamtube.js
+++ b/streamtube.js
@@ -534,17 +534,6 @@ module.exports = function(vectorField, bounds) {
 		}
 	}
 
-	// Replace NaNs and Infinities with non-NaN, finite maxDivergence
-	// Why we need this?
-	// The divergences variable is defined inside the loop and reset every time.
-	// This only fixes the last one?
-	var len = divergences.length;
-	for (var i=0; i<len; i++) {
-		if (!isFinite(divergences[i])) {
-			divergences[i] = maxDivergence;
-		}
-	}
-
 	var tubes = createTubes(streams, vectorField.colormap, maxDivergence, minDistance);
 
 	if (absoluteTubeSize) {

--- a/streamtube.js
+++ b/streamtube.js
@@ -236,9 +236,13 @@ var sampleMeshgrid = function(point, array, meshgrid, clampOverflow, gridFill) {
 	var yf = (y - mY0) / (mY1 - mY0);
 	var zf = (z - mZ0) / (mZ1 - mZ0);
 
-	if (xf < 0 || xf > 1 || isNaN(xf)) xf = 0;
-	if (yf < 0 || yf > 1 || isNaN(yf)) yf = 0;
-	if (zf < 0 || zf > 1 || isNaN(zf)) zf = 0;
+	// Likely we don't need these tests:
+	if (!isFinite(xf)) xf = 0;
+	if (!isFinite(yf)) yf = 0;
+	if (!isFinite(zf)) zf = 0;
+	xf = Math.max(0, Math.min(1, xf));
+	yf = Math.max(0, Math.min(1, yf));
+	zf = Math.max(0, Math.min(1, zf));
 
 	var x0off;
 	var x1off;
@@ -488,7 +492,7 @@ module.exports = function(vectorField, bounds) {
 
 		var dv = vectorField.getDivergence(p, v);
 		var dvLength = vec3.length(dv);
-		if (dvLength > maxDivergence && !isNaN(dvLength) && isFinite(dvLength)) {
+		if (isFinite(dvLength) && dvLength > maxDivergence) {
 			maxDivergence = dvLength;
 		}
 		// In case we need to do component-wise divergence visualization
@@ -518,7 +522,7 @@ module.exports = function(vectorField, bounds) {
 				velocities.push(v);
 				var dv = vectorField.getDivergence(np, v);
 				var dvLength = vec3.length(dv);
-				if (dvLength > maxDivergence && !isNaN(dvLength) && isFinite(dvLength)) {
+				if (isFinite(dvLength) && dvLength > maxDivergence) {
 					maxDivergence = dvLength;
 				}
 				// In case we need to do component-wise divergence visualization
@@ -531,10 +535,12 @@ module.exports = function(vectorField, bounds) {
 	}
 
 	// Replace NaNs and Infinities with non-NaN, finite maxDivergence
+	// Why we need this?
+	// The divergences variable is defined inside the loop and reset every time.
+	// This only fixes the last one?
 	var len = divergences.length;
 	for (var i=0; i<len; i++) {
-		var dvLength = divergences[i];
-		if (isNaN(dvLength) || !isFinite(dvLength)) {
+		if (!isFinite(divergences[i])) {
 			divergences[i] = maxDivergence;
 		}
 	}

--- a/streamtube.js
+++ b/streamtube.js
@@ -424,7 +424,7 @@ module.exports = function(vectorField, bounds) {
 	var absoluteTubeSize = vectorField.absoluteTubeSize;
 
 	if (!vectorField.gridFill) {
-		vectorField.gridFill = 'zyx';
+		vectorField.gridFill = 'xyz';
 	}
 
 	if (!vectorField.getDivergence) {

--- a/streamtube.js
+++ b/streamtube.js
@@ -424,10 +424,11 @@ module.exports = function(vectorField, bounds) {
 	}
 
 	var gridFill = vectorField.gridFill;
+
 	vectorField._grid = {};
 	if(gridFill.indexOf('-x') !== -1) { vectorField._grid.reversedX = true; }
-	if(gridFill.indexOf('-y') !== -1) { vectorField._grid.reversedZ = true; }
-	if(gridFill.indexOf('-z') !== -1) { vectorField._grid.reversedY = true; }
+	if(gridFill.indexOf('-y') !== -1) { vectorField._grid.reversedY = true; }
+	if(gridFill.indexOf('-z') !== -1) { vectorField._grid.reversedZ = true; }
 	vectorField._grid.filled = GRID_TYPES.indexOf(gridFill.replace(/-/g, '').replace(/\+/g, ''));
 
 	if (!vectorField.getVelocity) {

--- a/streamtube.js
+++ b/streamtube.js
@@ -418,11 +418,11 @@ module.exports = function(vectorField, bounds) {
 	if(gridFill.indexOf('-z') !== -1) { gridInfo.reversedZ = true; }
 	gridInfo.filled = GRID_TYPES.indexOf(gridFill.replace(/-/g, '').replace(/\+/g, ''));
 
-	var getVelocity = function(p) {
+	var getVelocity = vectorField.getVelocity || function(p) {
 		return sampleMeshgrid(p, vectorField, gridInfo);
 	};
 
-	var getDivergence = function(p, v0) {
+	var getDivergence = vectorField.getDivergence || function(p, v0) {
 		var dp = vec3.create();
 		var e = 0.0001;
 


### PR DESCRIPTION
The `gl-streamtube3d` module used to make assumptions about the order of input data which could be false in cases where the data cube was not filled in orders than `xyz` (i.e first `x` | next `y` | last  `z`).
This PR addresses this issue by considering the order of data.
Please refer to https://github.com/plotly/plotly.js/pull/4271 for more info.
I addition this PR refactors parts of the code 
- to avoid global temporary variables
- to reduce calls to read the length of arrays
- to simplify condition checks

@etpinard 